### PR TITLE
Fix postStartCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,9 +12,7 @@
 		}
 	},
 
-	"postStartCommand": {
-		"julia": "postStartCommand.sh"
-	},
+	"postStartCommand": "postStartCommand.sh",
 
 	"features": {
 		"ghcr.io/devcontainers/features/common-utils:2": {

--- a/.devcontainer/julia-pubtools/devcontainer.json
+++ b/.devcontainer/julia-pubtools/devcontainer.json
@@ -12,9 +12,7 @@
 		}
 	},
 
-	"postStartCommand": {
-		"julia": "postStartCommand.sh"
-	},
+	"postStartCommand": "postStartCommand.sh",
 
 	"features": {
 		"ghcr.io/devcontainers/features/common-utils:2": {


### PR DESCRIPTION
In case someone wants to extend the Dev Containers with a `postAttachCommand`.

Cross reference: https://github.com/b-data/data-science-devcontainers/commit/7d63d5fcae866f7ec9764c32658f7ca1d2793e04